### PR TITLE
Removed Bug UUID gen on update

### DIFF
--- a/lib/acqdat/model/device.ex
+++ b/lib/acqdat/model/device.ex
@@ -28,7 +28,7 @@ defmodule Acqdat.Model.Device do
   end
 
   def update(device, params) do
-    changeset = Device.changeset(device, params)
+    changeset = Device.update_changeset(device, params)
     Repo.update(changeset)
   end
 

--- a/lib/acqdat/model/sensor.ex
+++ b/lib/acqdat/model/sensor.ex
@@ -28,7 +28,7 @@ defmodule Acqdat.Model.Sensor do
   end
 
   def update(sensor, params) do
-    changeset = Sensor.changeset(sensor, params)
+    changeset = Sensor.update_changeset(sensor, params)
     Repo.update(changeset)
   end
 

--- a/lib/acqdat/schema/device.ex
+++ b/lib/acqdat/schema/device.ex
@@ -32,6 +32,7 @@ defmodule Acqdat.Schema.Device do
   @optional_params ~w(description)a
 
   @permitted @required_params ++ @optional_params
+  @update_required_params ~w(name access_token)a
 
   @spec changeset(
           __MODULE__.t(),
@@ -42,6 +43,18 @@ defmodule Acqdat.Schema.Device do
     |> cast(params, @permitted)
     |> add_uuid()
     |> validate_required(@required_params)
+    |> common_changeset()
+  end
+
+  def update_changeset(%__MODULE__{} = device, params) do
+    device
+    |> cast(params, @permitted)
+    |> validate_required(@update_required_params)
+    |> common_changeset()
+  end
+
+  def common_changeset(changeset) do
+    changeset
     |> unique_constraint(:name, name: :acqdat_devices_name_index)
     |> unique_constraint(:uuid, name: :acqdat_devices_uuid_index)
   end

--- a/lib/acqdat/schema/sensor.ex
+++ b/lib/acqdat/schema/sensor.ex
@@ -37,6 +37,7 @@ defmodule Acqdat.Schema.Sensor do
   end
 
   @permitted ~w(device_id sensor_type_id uuid name)a
+  @update_params ~w(device_id sensor_type_id name)a
 
   @spec changeset(
           __MODULE__.t(),
@@ -47,6 +48,18 @@ defmodule Acqdat.Schema.Sensor do
     |> cast(params, @permitted)
     |> add_uuid()
     |> validate_required(@permitted)
+    |> common_changeset()
+  end
+
+  def update_changeset(%__MODULE__{} = sensor, params) do
+    sensor
+    |> cast(params, @update_params)
+    |> validate_required(@permitted)
+    |> common_changeset()
+  end
+
+  def common_changeset(changeset) do
+    changeset
     |> assoc_constraint(:device)
     |> assoc_constraint(:sensor_type)
     |> unique_constraint(:name, name: :unique_sensor_per_device)


### PR DESCRIPTION
New UUID was being generated if the device
or sensor was updated fixed by adding separate
changeset for update.