### PR TITLE
Timestamp modify

### DIFF
--- a/lib/acqdat/schema/device.ex
+++ b/lib/acqdat/schema/device.ex
@@ -25,7 +25,7 @@ defmodule Acqdat.Schema.Device do
 
     has_many(:sensors, Sensor)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(name access_token uuid)a

--- a/lib/acqdat/schema/notification/sensor_notifications.ex
+++ b/lib/acqdat/schema/notification/sensor_notifications.ex
@@ -38,7 +38,7 @@ defmodule Acqdat.Schema.SensorNotifications do
     field(:alarm_status, :boolean, default: true)
     belongs_to(:sensor, Sensor, on_replace: :delete)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(sensor_id rule_values)a

--- a/lib/acqdat/schema/sensor.ex
+++ b/lib/acqdat/schema/sensor.ex
@@ -33,7 +33,7 @@ defmodule Acqdat.Schema.Sensor do
     belongs_to(:sensor_type, SensorType)
 
     has_many(:sensor_data, SensorData)
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @permitted ~w(device_id sensor_type_id uuid name)a

--- a/lib/acqdat/schema/sensor_data.ex
+++ b/lib/acqdat/schema/sensor_data.ex
@@ -24,7 +24,7 @@ defmodule Acqdat.Schema.SensorData do
     field(:datapoint, :map)
     belongs_to(:sensor, Sensor)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(inserted_timestamp datapoint sensor_id)a

--- a/lib/acqdat/schema/sensor_type.ex
+++ b/lib/acqdat/schema/sensor_type.ex
@@ -34,7 +34,7 @@ defmodule Acqdat.Schema.SensorType do
     field(:identifier, :string)
     field(:value_keys, {:array, :string})
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(name identifier value_keys)a

--- a/lib/acqdat/schema/tool-management/employee.ex
+++ b/lib/acqdat/schema/tool-management/employee.ex
@@ -22,7 +22,7 @@ defmodule Acqdat.Schema.ToolManagement.Employee do
     field(:uuid, :string)
     field(:role, :string)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_fields ~w(name phone_number uuid role)a

--- a/lib/acqdat/schema/tool-management/tool.ex
+++ b/lib/acqdat/schema/tool-management/tool.ex
@@ -25,7 +25,7 @@ defmodule Acqdat.Schema.ToolManagement.Tool do
 
     belongs_to(:tool_box, ToolBox)
     belongs_to(:tool_type, ToolType)
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required ~w(name tool_type_id uuid tool_box_id )a

--- a/lib/acqdat/schema/tool-management/tool_box.ex
+++ b/lib/acqdat/schema/tool-management/tool_box.ex
@@ -24,7 +24,7 @@ defmodule Acqdat.Schema.ToolManagement.ToolBox do
 
     has_many(:tools, Tool)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required_params ~w(name uuid)a

--- a/lib/acqdat/schema/tool-management/tool_issue.ex
+++ b/lib/acqdat/schema/tool-management/tool_issue.ex
@@ -22,7 +22,7 @@ defmodule Acqdat.Schema.ToolManagement.ToolIssue do
     belongs_to(:tool, Tool)
     belongs_to(:tool_box, ToolBox)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @permitted ~w(issue_time employee_id tool_id tool_box_id)a

--- a/lib/acqdat/schema/tool-management/tool_return.ex
+++ b/lib/acqdat/schema/tool-management/tool_return.ex
@@ -24,7 +24,7 @@ defmodule Acqdat.Schema.ToolManagement.ToolReturn do
     belongs_to(:tool_box, ToolBox)
     belongs_to(:tool_issue, ToolIssue)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @permitted ~w(return_time employee_id tool_id tool_box_id tool_issue_id)a

--- a/lib/acqdat/schema/tool-management/tool_type.ex
+++ b/lib/acqdat/schema/tool-management/tool_type.ex
@@ -11,7 +11,7 @@ defmodule Acqdat.Schema.ToolManagement.ToolType do
     field(:identifier, :string)
     field(:description, :string)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required ~w(identifier)a

--- a/lib/acqdat/schema/user.ex
+++ b/lib/acqdat/schema/user.ex
@@ -17,7 +17,7 @@ defmodule Acqdat.Schema.User do
     field(:password_confirmation, :string, virtual: true)
     field(:password_hash, :string)
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @required ~w(first_name email password password_confirmation)a

--- a/priv/repo/migrations/20190507060157_add_user_table.exs
+++ b/priv/repo/migrations/20190507060157_add_user_table.exs
@@ -10,7 +10,7 @@ defmodule Acqdat.Repo.Migrations.AddUserTable do
       add(:email, :citext, null: false)
       add(:password_hash, :string, null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("users", [:email])

--- a/priv/repo/migrations/20190508142907_add_device_table.exs
+++ b/priv/repo/migrations/20190508142907_add_device_table.exs
@@ -8,7 +8,7 @@ defmodule Acqdat.Repo.Migrations.AddDeviceTable do
       add(:access_token, :string, null: false)
       add(:description, :text)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_devices", [:name])

--- a/priv/repo/migrations/20190509071447_add_sensor_type_table.exs
+++ b/priv/repo/migrations/20190509071447_add_sensor_type_table.exs
@@ -9,7 +9,7 @@ defmodule Acqdat.Repo.Migrations.AddSensorTypeTable do
       add(:identifier, :string, null: false)
       add(:value_keys, {:array, :string}, null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_sensor_types", [:name])

--- a/priv/repo/migrations/20190509095142_add_sensor_table.exs
+++ b/priv/repo/migrations/20190509095142_add_sensor_table.exs
@@ -8,7 +8,7 @@ defmodule Acqdat.Repo.Migrations.AddSensorTable do
       add(:device_id, references("acqdat_devices", on_delete: :delete_all), null: false)
       add(:sensor_type_id, references("acqdat_sensor_types", on_delete: :restrict), null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_sensors", [:name, :device_id], name: :unique_sensor_per_device)

--- a/priv/repo/migrations/20190510055419_add_sensor_data_table.exs
+++ b/priv/repo/migrations/20190510055419_add_sensor_data_table.exs
@@ -3,11 +3,11 @@ defmodule Acqdat.Repo.Migrations.AddSensorDataTable do
 
   def change do
     create table("acqdat_sensor_data") do
-      add(:inserted_timestamp, :utc_datetime, null: false)
+      add(:inserted_timestamp, :timestamptz, null: false)
       add(:datapoint, :map, null: false)
       add(:sensor_id, references("acqdat_sensors", on_delete: :restrict), null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
   end
 end

--- a/priv/repo/migrations/20190528110130_add_sensor_notification.exs
+++ b/priv/repo/migrations/20190528110130_add_sensor_notification.exs
@@ -7,7 +7,7 @@ defmodule Acqdat.Repo.Migrations.AddSensorNotification do
       add(:sensor_id, references("acqdat_sensors", on_delete: :delete_all), null: false)
       add(:alarm_status, :boolean, default: true)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_sensor_notifications", [:sensor_id])

--- a/priv/repo/migrations/20190719071257_add_tm_employee_table.exs
+++ b/priv/repo/migrations/20190719071257_add_tm_employee_table.exs
@@ -9,7 +9,7 @@ defmodule Acqdat.Repo.Migrations.AddTmEmployeeTable do
       add(:uuid, :string, null: false)
       add(:role, :string, null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_tm_employees", [:uuid])

--- a/priv/repo/migrations/20190719080602_add_tm_tool_box_table.exs
+++ b/priv/repo/migrations/20190719080602_add_tm_tool_box_table.exs
@@ -7,7 +7,7 @@ defmodule Acqdat.Repo.Migrations.AddTmToolBoxTable do
       add(:description, :string)
       add(:uuid, :string, null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_tm_tool_boxes", [:uuid])

--- a/priv/repo/migrations/20190719093837_add_tm_tool_type_table.exs
+++ b/priv/repo/migrations/20190719093837_add_tm_tool_type_table.exs
@@ -6,7 +6,7 @@ defmodule Acqdat.Repo.Migrations.AddTmToolTypeTable do
       add(:identifier, :citext)
       add(:description, :string)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_tm_tool_types", [:identifier])

--- a/priv/repo/migrations/20190722060915_add_tool_table.exs
+++ b/priv/repo/migrations/20190722060915_add_tool_table.exs
@@ -11,7 +11,7 @@ defmodule Acqdat.Repo.Migrations.AddToolTable do
       add(:tool_box_id, references("acqdat_tm_tool_boxes", on_delete: :delete_all), null: false)
       add(:tool_type_id, references("acqdat_tm_tool_types", on_delete: :delete_all), null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_tm_tools", [:uuid])

--- a/priv/repo/migrations/20190725073115_add_tool_issue_return_tables.exs
+++ b/priv/repo/migrations/20190725073115_add_tool_issue_return_tables.exs
@@ -3,19 +3,19 @@ defmodule Acqdat.Repo.Migrations.AddToolIssueReturnTables do
 
   def change do
     create table("acqdat_tm_tool_issue") do
-      add(:issue_time, :utc_datetime, null: false)
+      add(:issue_time, :timestamptz, null: false)
 
       #associations
       add(:employee_id, references("acqdat_tm_employees", on_delete: :restrict), null: false)
       add(:tool_box_id, references("acqdat_tm_tool_boxes", on_delete: :restrict), null: false)
       add(:tool_id, references("acqdat_tm_tools", on_delete: :restrict), null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
 
     create table("acqdat_tm_tool_return") do
-      add(:return_time, :utc_datetime, null: false)
+      add(:return_time, :timestamptz, null: false)
 
       #associations
       add(:employee_id, references("acqdat_tm_employees", on_delete: :restrict), null: false)
@@ -23,7 +23,7 @@ defmodule Acqdat.Repo.Migrations.AddToolIssueReturnTables do
       add(:tool_id, references("acqdat_tm_tools", on_delete: :restrict), null: false)
       add(:tool_issue_id, references("acqdat_tm_tool_issue", on_delete: :restrict), null: false)
 
-      timestamps()
+      timestamps(type: :timestamptz)
     end
 
     create unique_index("acqdat_tm_tool_return", [:tool_issue_id], name: :unique_issue_for_return)

--- a/test/acqdat/domain/notification_test.exs
+++ b/test/acqdat/domain/notification_test.exs
@@ -60,6 +60,7 @@ defmodule Acqdat.Domain.NotificationTest do
       params = %{device: device, data: data}
 
       result = Notification.handle_notification(params)
+      assert {:ok, "notification_sent"} == result
     end
   end
 end

--- a/test/acqdat/model/sensor_data_test.exs
+++ b/test/acqdat/model/sensor_data_test.exs
@@ -3,6 +3,7 @@ defmodule Acqdat.Model.SensorDataTest do
   use Acqdat.DataCase
   import Acqdat.Support.Factory
   alias Acqdat.Model.{SensorData, Sensor}
+  alias Acqdat.Repo
 
   describe "get_by_time_range/2" do
     test "returns data in the given time stamp" do
@@ -16,7 +17,9 @@ defmodule Acqdat.Model.SensorDataTest do
       start_time = Timex.shift(DateTime.utc_now(), minutes: -1)
       end_time = DateTime.utc_now()
 
-      result = SensorData.get_by_time_range(start_time, end_time)
+      query = SensorData.get_by_time_range(start_time, end_time)
+      result = Repo.all(query)
+
       assert length(result) == 4
     end
 
@@ -31,7 +34,9 @@ defmodule Acqdat.Model.SensorDataTest do
       start_time = Timex.shift(DateTime.utc_now(), minutes: -4)
       end_time = Timex.shift(DateTime.utc_now(), minutes: -2)
 
-      result = SensorData.get_by_time_range(start_time, end_time)
+      query = SensorData.get_by_time_range(start_time, end_time)
+      result = Repo.all(query)
+
       assert result == []
     end
   end

--- a/test/acqdat/model/tool-management/employee_test.exs
+++ b/test/acqdat/model/tool-management/employee_test.exs
@@ -24,7 +24,7 @@ defmodule Acqdat.Model.ToolManagament.EmployeeTest do
     setup :employee_list
 
     @tag employee_count: 2
-    test "returns a list of employee", context do
+    test "returns a list of employee" do
       result = Employee.get_all()
       assert length(result) == 2
     end

--- a/test/acqdat/model/tool-management/tool_test.exs
+++ b/test/acqdat/model/tool-management/tool_test.exs
@@ -42,10 +42,7 @@ defmodule Acqdat.Model.ToolManagament.ToolTest do
     end
 
     @tag tool_count: 3
-    test "returns [] if no uuid match", context do
-      %{tools: tools} = context
-      tool_uuids = Enum.map(tools, fn tool -> tool.uuid end)
-
+    test "returns [] if no uuid match" do
       tool_ids = Tool.get_all_by_uuids_and_status(["1234", "abcd"], "in_inventory")
       assert tool_ids == []
     end

--- a/test/acqdat/schema/notification/sensor_notification_test.exs
+++ b/test/acqdat/schema/notification/sensor_notification_test.exs
@@ -63,10 +63,8 @@ defmodule Acqdat.Schema.SensorNotificationsTest do
       refute validity
 
       assert %{
-               rule_values: [
-                 "humid: {lower_limit: [\"is invalid\"] }\n{upper_limit: [\"is invalid\"] }\n"
-               ]
-             } == errors_on(changeset)
+        rule_values: ["{\"humid\":{\"lower_limit\":[\"is invalid\"],\"upper_limit\":[\"is invalid\"]}}"]
+      } == errors_on(changeset)
     end
   end
 end

--- a/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
+++ b/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
@@ -2,7 +2,6 @@ defmodule AcqdatWeb.API.ToolManagementControllerTest do
   use ExUnit.Case, async: true
   use AcqdatWeb.ConnCase
   import Acqdat.Support.Factory
-  alias AcqdatWeb.API.ToolManagementController
 
   setup %{conn: conn} do
     conn = put_req_header(conn, "content-type", "application/json")
@@ -42,12 +41,12 @@ defmodule AcqdatWeb.API.ToolManagementControllerTest do
         "transaction" => "issue"}
 
       result = conn |> post("/api/tl-mgmt/tool-transaction", params) |> json_response(200)
-      assert %{"status" => "success", "data" => "transaction issue succedded"} == result
+      assert %{"status" => "success", "data" => "transaction issue succeded"} == result
     end
 
     @tag tool_count: 2
     test "error if non tool ids not found", context do
-      %{tools: tools, employee: employee, tool_box: tool_box,
+      %{employee: employee, tool_box: tool_box,
       conn: conn} = context
       params = %{"user_uuid" => employee.uuid,
         "tool_box_uuid" => tool_box.uuid, "tool_ids" => ["1234", "abcd"],
@@ -73,7 +72,7 @@ defmodule AcqdatWeb.API.ToolManagementControllerTest do
         "tool_box_uuid" => tool_box.uuid, "tool_ids" => tool_uuid_list(tools),
         "transaction" => "return"}
       result = conn |> post("/api/tl-mgmt/tool-transaction", return_params) |> json_response(200)
-      assert result == %{"data" => "transaction return succedded", "status" => "success"}
+      assert result == %{"data" => "transaction return succeded", "status" => "success"}
     end
 
     @tag tool_count: 2

--- a/test/acqdat_web/controllers/page_controller_test.exs
+++ b/test/acqdat_web/controllers/page_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule AcqdatWeb.PageControllerTest do
   use AcqdatWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "GET /", %{conn: _conn} do
   end
 end


### PR DESCRIPTION
# Why?
The timestamps present in the app in schema, as well as migrations, is timestamp instead of timestamptz. This may result in issues later on. `timestamp` does not store any timezone information not even` UTC`, `timestamptz` does.
This would keep everything properly in` Etc/UTC` zone.

## Changes 
* Modified migration timestamps to use `timestamptz` instead of timestamp
  as zone information is not stored in the latter.
* Modified generated inserted_at and updated_at to utc timestamps.
* Update failing tests for timestamp modification
