### PR TITLE
RFID APIs

### DIFF
--- a/lib/acqdat/context/tool_management.ex
+++ b/lib/acqdat/context/tool_management.ex
@@ -41,6 +41,33 @@ defmodule Acqdat.Context.ToolManagement do
       end
   end
 
+  def verify_tool(%{tool_uuid: tool_uuid}) do
+    Tool.get(%{uuid: tool_uuid})
+  end
+
+  def employees(_facotry_id) do
+    Employee.get_all()
+  end
+
+  def tool_box_status(tool_box_uuid) do
+    case ToolBox.get(%{uuid: tool_box_uuid}) do
+      {:ok, tool_box} ->
+        {:ok, Repo.preload(tool_box, :tools)}
+      {:error, _error} = error ->
+        error
+    end
+  end
+
+  @spec employee_transaction_status(non_neg_integer) :: {:ok, []} | {:error, any}
+  def employee_transaction_status(employee_uuid) do
+    case Employee.get(%{uuid: employee_uuid}) do
+      {:ok, employee} ->
+        {:ok, Employee.employee_tool_issue_status(employee.id)}
+      {:error, _message} = error->
+          error
+    end
+  end
+
   ##################################### Private Functions #####################
 
   defp run_transaction(tool_manifest, status = "issue") do

--- a/lib/acqdat/context/tool_management.ex
+++ b/lib/acqdat/context/tool_management.ex
@@ -52,7 +52,8 @@ defmodule Acqdat.Context.ToolManagement do
   def tool_box_status(tool_box_uuid) do
     case ToolBox.get(%{uuid: tool_box_uuid}) do
       {:ok, tool_box} ->
-        {:ok, Repo.preload(tool_box, :tools)}
+        tool_box = Repo.preload(tool_box, :tools)
+        {:ok, tool_box.tools}
       {:error, _error} = error ->
         error
     end

--- a/lib/acqdat/schema/tool-management/employee.ex
+++ b/lib/acqdat/schema/tool-management/employee.ex
@@ -5,6 +5,7 @@ defmodule Acqdat.Schema.ToolManagement.Employee do
 
   use Acqdat.Schema
   @emp_prefix "U"
+  @roles ~w(supervisor worker)s
 
   @typedoc """
   `name`: name of the employee.
@@ -45,10 +46,15 @@ defmodule Acqdat.Schema.ToolManagement.Employee do
     |> common_changeset()
   end
 
+  def employee_roles() do
+    @roles
+  end
+
   defp common_changeset(changeset) do
     changeset
     |> validate_required(@required_fields)
     |> validate_length(:phone_number, max: 10, min: 5)
+    |> validate_inclusion(:role, @roles)
     |> unique_constraint(:name, name: :acqdat_tm_employees_name_phone_number_index,
       message: "User already exists!")
   end

--- a/lib/acqdat/schema/tool-management/tool_return.ex
+++ b/lib/acqdat/schema/tool-management/tool_return.ex
@@ -29,8 +29,8 @@ defmodule Acqdat.Schema.ToolManagement.ToolReturn do
 
   @permitted ~w(return_time employee_id tool_id tool_box_id tool_issue_id)a
 
-  def changeset(%__MODULE__{} = tool_issue, params) do
-    tool_issue
+  def changeset(%__MODULE__{} = tool_return, params) do
+    tool_return
     |> cast(params, @permitted)
     |> validate_required(@permitted)
     |> assoc_constraint(:employee)

--- a/lib/acqdat_web/controllers/api/tool-management/tool_management_controller.ex
+++ b/lib/acqdat_web/controllers/api/tool-management/tool_management_controller.ex
@@ -2,6 +2,7 @@ defmodule AcqdatWeb.API.ToolManagementController do
   use AcqdatWeb, :controller
   use Params
   import AcqdatWeb.Helpers
+
   defparams(
     tool_transaction_params(%{
       user_uuid!: :string,
@@ -11,12 +12,96 @@ defmodule AcqdatWeb.API.ToolManagementController do
     })
   )
 
+  defparams(
+    verify_tool(%{
+      tool_box_uuid!: :string,
+      tool_uuid!: :string
+    })
+  )
+
+  defparams(
+    verify_employee_status(%{
+      employee_uuid!: :string
+    })
+  )
+
+  defparams(
+    verify_tool_box_status(%{
+      tool_box_uuid!: :string
+    })
+  )
+
   alias Acqdat.Context.ToolManagement
 
   def verify_employee(conn, params) do
     %{"user_uuid" => uuid} = params
     {status, data} = ToolManagement.verify_employee(%{uuid: uuid})
     render(conn, "employee_verified.json", status: status, data: data)
+  end
+
+  def employee_tool_issue_status(conn, params) do
+    changeset = verify_employee_status(params)
+
+    with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
+    {:ok, tools} <- ToolManagement.employee_transaction_status(data.employee_uuid)
+    do
+      render(conn, "tools.json", tools: tools)
+    else
+      {:extract, {:error, changeset}} ->
+        errors = extract_changeset_errors(changeset)
+        conn
+        |> put_status(400)
+        |> render("transaction_error.json", errors: errors)
+      {:error, errors} ->
+        conn
+        |> put_status(404)
+        |> render("error.json", errors: errors)
+    end
+  end
+
+  def tool_box_status(conn, params) do
+    changeset = verify_tool_box_status(params)
+
+    with {:extract, {:ok, data}} <- {:extract, extract_changeset_data(changeset)},
+      {:ok, tools} <- ToolManagement.tool_box_status(data.tool_box_uuid)
+    do
+      render(conn, "tools.json", tools: tools)
+    else
+    {:extract, {:error, changeset}} ->
+      errors = extract_changeset_errors(changeset)
+      conn
+      |> put_status(400)
+      |> render("transaction_error.json", errors: errors)
+    {:error, errors} ->
+      conn
+      |> put_status(401)
+      |> render("error.json", errors: errors)
+    end
+  end
+
+  def verify_tool(conn, params) do
+    changeset = verify_tool(params)
+
+    with {:extract, {:ok, tool_params}} <- {:extract, extract_changeset_data(changeset)},
+      {:tool, {:ok, tool}} <- {:tool, ToolManagement.verify_tool(tool_params)}
+    do
+      render(conn, "tool.json", tool: tool)
+    else
+      {:extract, {:error, changeset}} ->
+        errors = extract_changeset_errors(changeset)
+        conn
+        |> put_status(400)
+        |> render("transaction_error.json", errors: errors)
+      {:tool, {:error, errors}} ->
+        conn
+        |> put_status(401)
+        |> render("error.json", errors: errors)
+    end
+  end
+
+  def list_employees(conn, _params) do
+    employees = ToolManagement.employees(nil)
+    render(conn, "employees.json", employees: employees)
   end
 
   def tool_transaction(conn, params) do
@@ -29,9 +114,13 @@ defmodule AcqdatWeb.API.ToolManagementController do
     else
       {:extract, {:error, changeset}} ->
         errors = extract_changeset_errors(changeset)
-        render(conn, "transaction_error.json", errors: errors)
+        conn
+        |> put_status(400)
+        |> render("transaction_error.json", errors: errors)
       {:add_data, {:error, errors}} ->
-        render(conn, "transaction_error.json", errors: errors)
+        conn
+        |> put_status(400)
+        |> render("transaction_error.json", errors: errors)
     end
   end
 end

--- a/lib/acqdat_web/router.ex
+++ b/lib/acqdat_web/router.ex
@@ -85,6 +85,12 @@ defmodule AcqdatWeb.Router do
     post "/token", TokenController, :create
     post("/tl-mgmt/employee/identify", ToolManagementController, :verify_employee)
     post("/tl-mgmt/tool-transaction", ToolManagementController, :tool_transaction)
+    post("tl-mgmt/employees", ToolManagementController, :list_employees)
+    post("tl-mgmt/verify-tool", ToolManagementController, :verify_tool)
+    post("tl-mgmt/employee-tool-issue-status", ToolManagementController,
+      :employee_tool_issue_status)
+    post("tl-mgmt/tool-box-status", ToolManagementController,
+      :tool_box_status)
   end
 
   scope "/api", AcqdatWeb.API do

--- a/lib/acqdat_web/templates/tool_management/employee/_form.html.eex
+++ b/lib/acqdat_web/templates/tool_management/employee/_form.html.eex
@@ -26,7 +26,7 @@
 <div class="form-group row">
   <%= label f, :role, "Role", class: "col-2 col-form-table" %>
   <div class="col-5">
-    <%= text_input(f, :role, class: "form-control") %>
+   <%= select(f, :role, employee_role(), class: "form-control", prompt: "Choose Role") %>
   </div>
   <%= error_tag(f, :role) %>
 </div>

--- a/lib/acqdat_web/views/api/tool-management/tool_management_view.ex
+++ b/lib/acqdat_web/views/api/tool-management/tool_management_view.ex
@@ -12,10 +12,50 @@ defmodule AcqdatWeb.API.ToolManagementView do
       }
     }
   end
+
+  def render("tool.json", %{tool: tool}) do
+    %{
+      tool: %{
+        name: tool.name,
+        uuid: tool.uuid,
+        status: tool.status
+      }
+    }
+  end
+
+  def render("tools.json", %{tools: tools}) do
+    %{
+      tools: render_many(tools, __MODULE__, "tool.json", as: :tool)
+    }
+  end
+
   def render("employee_verified.json", %{status: :error, data: message}) do
     %{
       status: @status_unidentitified,
       message: message
+    }
+  end
+
+  def render("employee.json", %{employee: employee}) do
+    %{
+      id: employee.id,
+      name: employee.name,
+      role: employee.role,
+      uuid: employee.uuid,
+      phone_number: employee.phone_number
+    }
+  end
+
+  def render("error.json", %{errors: errors}) do
+    %{
+      errors: errors
+    }
+  end
+
+  def render("employees.json", %{employees: employees}) do
+    %{
+      employees: render_many(employees, __MODULE__, "employee.json",
+        as: :employee)
     }
   end
 

--- a/lib/acqdat_web/views/tool-management/employee_view.ex
+++ b/lib/acqdat_web/views/tool-management/employee_view.ex
@@ -1,3 +1,8 @@
 defmodule AcqdatWeb.ToolManagement.EmployeeView do
   use AcqdatWeb, :view
+  alias Acqdat.Schema.ToolManagement.Employee
+  def employee_role() do
+    Employee.employee_roles()
+  end
+
 end

--- a/test/acqdat/schema/tool-management/employee_test.exs
+++ b/test/acqdat/schema/tool-management/employee_test.exs
@@ -8,7 +8,7 @@ defmodule Acqdat.Schema.ToolManagement.EmployeeTest do
 
   describe "create_changeset/2" do
     test "returns valid changeset" do
-      params = %{name: "IronMan", phone_number: "1234567", role: "employee"}
+      params = %{name: "IronMan", phone_number: "1234567", role: "worker"}
       %{valid?: validity} = Employee.create_changeset(%Employee{}, params)
       assert validity
     end

--- a/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
+++ b/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
@@ -96,6 +96,142 @@ defmodule AcqdatWeb.API.ToolManagementControllerTest do
 
   end
 
+  describe "list_employees/2" do
+    setup :employee_list
+
+    @tag employee_count: 2
+    test "returns a list of employees", context do
+      %{employees: employees, conn: conn} = context
+      params = %{factory_id: 123}
+      result = conn |> post("/api/tl-mgmt/employees", params) |> json_response(200)
+      assert length(result["employees"]) == length(employees)
+    end
+
+    @tag employee_count: 0
+    test "returns empty list if employees not found", context do
+      %{conn: conn} = context
+      params = %{factory_id: 123}
+      result = conn |> post("/api/tl-mgmt/employees", params) |> json_response(200)
+      assert result["employees"] == []
+    end
+  end
+
+  describe "verify_tools/2" do
+    setup do
+      tool_box = insert(:tool_box)
+      [tool_box: tool_box]
+    end
+    setup :tool_list
+
+    @tag tool_count: 0
+    test "error if required params missing", context do
+      %{conn: conn} = context
+      params = %{}
+      result = conn |> post("/api/tl-mgmt/verify-tool", params) |> json_response(400)
+      assert result == %{
+        "errors" => %{
+          "tool_box_uuid" => ["can't be blank"],
+          "tool_uuid" => ["can't be blank"]
+        },
+        "status" => "error"
+      }
+    end
+
+    @tag tool_count: 1
+    test "error if tool not found", context do
+      %{conn: conn, tool_box: tool_box} = context
+      params = %{tool_uuid: "acb1", tool_box_uuid: tool_box.uuid}
+      result =
+        conn
+        |> post("/api/tl-mgmt/verify-tool", params)
+        |> json_response(401)
+      assert result == %{"errors" => "not found"}
+    end
+
+    @tag tool_count: 1
+    test "return tool if found", context do
+      %{conn: conn, tool_box: tool_box, tools: [tool]} = context
+      params = %{tool_uuid: tool.uuid, tool_box_uuid: tool_box.uuid}
+      result =
+        conn
+        |> post("/api/tl-mgmt/verify-tool", params)
+        |> json_response(200)
+      assert Map.has_key?(result["tool"], "name")
+      assert Map.has_key?(result["tool"], "status")
+      assert Map.has_key?(result["tool"], "uuid")
+    end
+  end
+
+  describe "employee_tool_status" do
+    setup do
+      employee = insert(:employee)
+      tool_box = insert(:tool_box)
+      tool_issue_1 = insert(:tool_issue, employee: employee, tool_box: tool_box)
+      tool_issue_2 = insert(:tool_issue, employee: employee, tool_box: tool_box)
+      tool_issue_list = [tool_issue_1, tool_issue_2]
+
+      [employee: employee, tool_issue_list: tool_issue_list]
+    end
+
+    test "error if params misisng", context do
+      %{conn: conn} = context
+
+      params = %{}
+      result = conn
+        |> post("/api/tl-mgmt/employee-tool-issue-status", params)
+        |> json_response(400)
+      assert result == %{"errors" => %{
+          "employee_uuid" => ["can't be blank"]},
+          "status" => "error"
+      }
+    end
+
+    test "returns error if employee not found", context do
+      %{conn: conn} = context
+
+      params = %{employee_uuid: "abc1234"}
+      result = conn
+        |> post("/api/tl-mgmt/employee-tool-issue-status", params)
+        |> json_response(404)
+
+      assert result == %{"errors" => "not found"}
+    end
+
+    test "returns issued but not returned", context do
+      %{tool_issue_list: tool_issue_list, employee: employee, conn: conn}
+        = context
+      [tool_issue_1, tool_issue_2] = tool_issue_list
+
+      # return tool 1
+      tool_return(tool_issue_1)
+
+      params = %{employee_uuid: employee.uuid}
+      result = conn
+        |> post("/api/tl-mgmt/employee-tool-issue-status", params)
+        |> json_response(200)
+      assert Map.has_key?(result, "tools")
+      assert length(result["tools"]) == 1
+    end
+
+    test "returns empty list if no issued tools with employee", context do
+      %{tool_issue_list: tool_issue_list, employee: employee, conn: conn}
+        = context
+      [tool_issue_1, tool_issue_2] = tool_issue_list
+
+      # return tool 1
+      tool_return(tool_issue_1)
+      tool_return(tool_issue_2)
+
+      params = %{employee_uuid: employee.uuid}
+      result = conn
+        |> post("/api/tl-mgmt/employee-tool-issue-status", params)
+        |> json_response(200)
+
+      assert Map.has_key?(result, "tools")
+      assert result["tools"] == []
+    end
+  end
+
   defp tool_uuid_list(tools) do
     Enum.map(tools, fn tool ->
       tool.uuid

--- a/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
+++ b/test/acqdat_web/controllers/api/tool-management/tool_management_controller_test.exs
@@ -232,6 +232,27 @@ defmodule AcqdatWeb.API.ToolManagementControllerTest do
     end
   end
 
+  describe "tool_box_status/2" do
+    setup do
+      employee = insert(:employee)
+      tool_box = insert(:tool_box)
+
+      [employee: employee, tool_box: tool_box]
+    end
+
+    setup :tool_list
+
+    @tag tool_count: 3
+    test "returns status of all tools in the tool box", context do
+      %{conn: conn, tool_box: tool_box} = context
+
+      params = %{tool_box_uuid: tool_box.uuid}
+      result = conn |> post("/api/tl-mgmt/tool-box-status", params) |> json_response(200)
+      assert Map.has_key?(result, "tools")
+      assert length(result["tools"]) == 3
+    end
+  end
+
   defp tool_uuid_list(tools) do
     Enum.map(tools, fn tool ->
       tool.uuid

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -15,7 +15,8 @@ defmodule Acqdat.Support.Factory do
     ToolType,
     ToolBox,
     Tool,
-    ToolIssue
+    ToolIssue,
+    ToolReturn
   }
 
   def user_factory() do
@@ -79,7 +80,7 @@ defmodule Acqdat.Support.Factory do
       name: sequence(:employee_name, &"Employee#{&1}"),
       phone_number: "123456",
       address: "54 Peach Street, Gotham",
-      role: "big boss",
+      role: "worker",
       uuid: "U" <> permalink(4)
     }
   end
@@ -118,7 +119,7 @@ defmodule Acqdat.Support.Factory do
     [tools: tools]
   end
 
-  def tool_issue() do
+  def tool_issue_factory() do
     %ToolIssue{
       employee: build(:employee),
       tool: build(:tool),
@@ -126,6 +127,19 @@ defmodule Acqdat.Support.Factory do
 
       issue_time: DateTime.truncate(DateTime.utc_now(), :second)
     }
+  end
+
+  def tool_return(tool_issue) do
+    return_params = %{
+      employee_id: tool_issue.employee_id,
+      tool_id: tool_issue.tool.id,
+      tool_box_id: tool_issue.tool_box.id,
+      tool_issue_id: tool_issue.id,
+
+      return_time: DateTime.truncate(DateTime.utc_now(), :second)
+    }
+    changeset = ToolReturn.changeset(%ToolReturn{}, return_params)
+    Repo.insert(changeset)
   end
 
 end


### PR DESCRIPTION
Add APIs to handle interaction with the RFID app. The client should be able to handle login and do configuration whereas the user should be able to issue tools, returns tools and check status.
