### PR TITLE
Add Card UUID for employee and tools

### DIFF
--- a/lib/acqdat/context/tool_management.ex
+++ b/lib/acqdat/context/tool_management.ex
@@ -41,8 +41,11 @@ defmodule Acqdat.Context.ToolManagement do
       end
   end
 
+  @doc """
+  Verifies a tool by it's rfid card uuid.
+  """
   def verify_tool(%{tool_uuid: tool_uuid}) do
-    Tool.get(%{uuid: tool_uuid})
+    Tool.get(%{card_uuid: tool_uuid})
   end
 
   def employees(_facotry_id) do
@@ -59,9 +62,15 @@ defmodule Acqdat.Context.ToolManagement do
     end
   end
 
+  @doc """
+  Returns record of tools issued by the employee.
+
+  ## See
+  `Acqdat.Schema.ToolManagement.ToolIssue`
+  """
   @spec employee_transaction_status(non_neg_integer) :: {:ok, []} | {:error, any}
   def employee_transaction_status(employee_uuid) do
-    case Employee.get(%{uuid: employee_uuid}) do
+    case Employee.get(%{card_uuid: employee_uuid}) do
       {:ok, employee} ->
         {:ok, Employee.employee_tool_issue_status(employee.id)}
       {:error, _message} = error->

--- a/lib/acqdat/model/tool-management/tool.ex
+++ b/lib/acqdat/model/tool-management/tool.ex
@@ -22,7 +22,6 @@ defmodule Acqdat.Model.ToolManagement.Tool  do
     end
   end
 
-
   def get(query) when is_map(query) do
     case Repo.get_by(Tool, query) do
       nil ->
@@ -48,11 +47,18 @@ defmodule Acqdat.Model.ToolManagement.Tool  do
     |> Repo.delete()
   end
 
+
+  @doc """
+  Returns a list of tools, the `card_uuid` of which is present in
+  supplied `uuids` list and corresponds to status supplied.
+
+  > The status can be `issued` or `in_inventory`.
+  """
   @spec get_all_by_uuids_and_status(list, String.t()) :: [non_neg_integer]
   def get_all_by_uuids_and_status(uuids, status) do
     query = from(
       tool in Tool,
-      where: tool.uuid in ^uuids and tool.status == ^status,
+      where: tool.card_uuid in ^uuids and tool.status == ^status,
       select: tool.id
     )
     Repo.all(query)

--- a/lib/acqdat/schema/tool-management/employee.ex
+++ b/lib/acqdat/schema/tool-management/employee.ex
@@ -22,11 +22,12 @@ defmodule Acqdat.Schema.ToolManagement.Employee do
     field(:address, :string)
     field(:uuid, :string)
     field(:role, :string)
+    field(:card_uuid, :string)
 
     timestamps(type: :utc_datetime)
   end
 
-  @required_fields ~w(name phone_number uuid role)a
+  @required_fields ~w(name phone_number uuid role card_uuid)a
   @optional_fields ~w(address)a
 
   @permitted @required_fields ++ @optional_fields

--- a/lib/acqdat/schema/tool-management/tool.ex
+++ b/lib/acqdat/schema/tool-management/tool.ex
@@ -22,13 +22,14 @@ defmodule Acqdat.Schema.ToolManagement.Tool do
     field(:name, :string)
     field(:status, :string, default: "in_inventory")
     field(:description, :string)
+    field(:card_uuid, :string)
 
     belongs_to(:tool_box, ToolBox)
     belongs_to(:tool_type, ToolType)
     timestamps(type: :utc_datetime)
   end
 
-  @required ~w(name tool_type_id uuid tool_box_id )a
+  @required ~w(name tool_type_id uuid tool_box_id card_uuid)a
   @optional ~w(description status)a
 
   @permitted @required ++ @optional

--- a/lib/acqdat_web/controllers/api/tool-management/tool_management_controller.ex
+++ b/lib/acqdat_web/controllers/api/tool-management/tool_management_controller.ex
@@ -35,7 +35,7 @@ defmodule AcqdatWeb.API.ToolManagementController do
 
   def verify_employee(conn, params) do
     %{"user_uuid" => uuid} = params
-    {status, data} = ToolManagement.verify_employee(%{uuid: uuid})
+    {status, data} = ToolManagement.verify_employee(%{card_uuid: uuid})
     render(conn, "employee_verified.json", status: status, data: data)
   end
 

--- a/lib/acqdat_web/router.ex
+++ b/lib/acqdat_web/router.ex
@@ -94,11 +94,11 @@ defmodule AcqdatWeb.Router do
     post "/sensor/:id/data", SensorController, :data
     post("/tl-mgmt/employee/identify", ToolManagementController, :verify_employee)
     post("/tl-mgmt/tool-transaction", ToolManagementController, :tool_transaction)
-    post("tl-mgmt/employees", ToolManagementController, :list_employees)
-    post("tl-mgmt/verify-tool", ToolManagementController, :verify_tool)
-    post("tl-mgmt/employee-tool-issue-status", ToolManagementController,
+    post("/tl-mgmt/employees", ToolManagementController, :list_employees)
+    post("/tl-mgmt/verify-tool", ToolManagementController, :verify_tool)
+    post("/tl-mgmt/employee-tool-issue-status", ToolManagementController,
       :employee_tool_issue_status)
-    post("tl-mgmt/tool-box-status", ToolManagementController,
+    post("/tl-mgmt/tool-box-status", ToolManagementController,
       :tool_box_status)
 
   end

--- a/lib/acqdat_web/templates/tool_management/employee/_form.html.eex
+++ b/lib/acqdat_web/templates/tool_management/employee/_form.html.eex
@@ -8,6 +8,14 @@
 </div>
 
 <div class="form-group row">
+  <%= label f, :card_uuid, "RFID Card UUID", class: "col-2 col-form-table" %>
+  <div class="col-5">
+    <%= text_input(f, :card_uuid, class: "form-control") %>
+  </div>
+  <%= error_tag(f, :card_uuid) %>
+</div>
+
+<div class="form-group row">
   <%= label f, :phone_number, "Phone Number", class: "col-2 col-form-table" %>
   <div class="col-5">
     <%= text_input(f, :phone_number, class: "form-control") %>
@@ -30,6 +38,7 @@
   </div>
   <%= error_tag(f, :role) %>
 </div>
+
 
 <div class="form-group mb-0  row">
   <div class="col-9">

--- a/lib/acqdat_web/templates/tool_management/tool/_form.html.eex
+++ b/lib/acqdat_web/templates/tool_management/tool/_form.html.eex
@@ -8,6 +8,14 @@
 </div>
 
 <div class="form-group row">
+  <%= label f, :card_uuid, "RFID Card UUID", class: "col-2 col-form-table" %>
+  <div class="col-5">
+    <%= text_input(f, :card_uuid, class: "form-control") %>
+  </div>
+  <%= error_tag(f, :card_uuid) %>
+</div>
+
+<div class="form-group row">
   <%= label f, :description, "Description", class: "col-2 col-form-table" %>
   <div class="col-5">
     <%= textarea(f, :description, class: "form-control") %>

--- a/priv/repo/migrations/20200114075104_add_card_uuids.exs
+++ b/priv/repo/migrations/20200114075104_add_card_uuids.exs
@@ -1,0 +1,18 @@
+defmodule Acqdat.Repo.Migrations.AddCardUuids do
+  use Ecto.Migration
+
+  def change do
+    alter table("acqdat_tm_employees") do
+      add(:card_uuid, :string, null: false)
+    end
+
+    alter table("acqdat_tm_tools") do
+      add(:card_uuid, :string, null: false)
+    end
+
+    create unique_index("acqdat_tm_employees", [:card_uuid])
+    create unique_index("acqdat_tm_tools", [:card_uuid])
+
+  end
+
+end

--- a/test/acqdat/model/tool-management/employee_test.exs
+++ b/test/acqdat/model/tool-management/employee_test.exs
@@ -8,14 +8,15 @@ defmodule Acqdat.Model.ToolManagament.EmployeeTest do
 
   describe "create/1" do
     test "creates an employee with supplied params" do
-      params = %{name: "IronMan", phone_number: "1234567", role: "worker"}
+      params = %{name: "IronMan", phone_number: "1234567", role: "worker",
+        card_uuid: permalink(4)}
       assert {:ok, _employee} = Employee.create(params)
     end
 
     test "fails if existing name and phone number combination used" do
       employee = insert(:employee)
       params = %{name: employee.name, phone_number: employee.phone_number,
-        role: "worker"}
+        role: "worker", card_uuid: permalink(4) }
       assert {:error, changeset} = Employee.create(params)
       assert %{name: ["User already exists!"]} == errors_on(changeset)
     end

--- a/test/acqdat/model/tool-management/tool_test.exs
+++ b/test/acqdat/model/tool-management/tool_test.exs
@@ -23,7 +23,7 @@ defmodule Acqdat.Model.ToolManagament.ToolTest do
 
   end
 
-  describe "get_all_by_uuids/1" do
+  describe "get_all_by_card_uuids/1" do
     setup  do
       tool_box = insert(:tool_box)
 
@@ -35,7 +35,7 @@ defmodule Acqdat.Model.ToolManagament.ToolTest do
     @tag tool_count: 3
     test "returns a list of tool ids", context do
       %{tools: tools} = context
-      tool_uuids = Enum.map(tools, fn tool -> tool.uuid end)
+      tool_uuids = Enum.map(tools, fn tool -> tool.card_uuid end)
 
       tool_ids = Tool.get_all_by_uuids_and_status(tool_uuids, "in_inventory")
       assert length(tool_ids) == length(tool_uuids)

--- a/test/acqdat/schema/tool-management/employee_test.exs
+++ b/test/acqdat/schema/tool-management/employee_test.exs
@@ -8,7 +8,8 @@ defmodule Acqdat.Schema.ToolManagement.EmployeeTest do
 
   describe "create_changeset/2" do
     test "returns valid changeset" do
-      params = %{name: "IronMan", phone_number: "1234567", role: "worker"}
+      params = %{name: "IronMan", phone_number: "1234567", role: "worker",
+        card_uuid: permalink(4)}
       %{valid?: validity} = Employee.create_changeset(%Employee{}, params)
       assert validity
     end
@@ -20,7 +21,8 @@ defmodule Acqdat.Schema.ToolManagement.EmployeeTest do
       assert %{
         name: ["can't be blank"],
         phone_number: ["can't be blank"],
-        role: ["can't be blank"]
+        role: ["can't be blank"],
+        card_uuid: ["can't be blank"]
       } == errors_on(changeset)
     end
   end

--- a/test/acqdat/schema/tool-management/tool_test.exs
+++ b/test/acqdat/schema/tool-management/tool_test.exs
@@ -21,20 +21,23 @@ defmodule Acqdat.Schema.ToolManagement.ToolTest do
       assert %{
         name: ["can't be blank"],
         tool_box_id: ["can't be blank"],
-        tool_type_id: ["can't be blank"]
+        tool_type_id: ["can't be blank"],
+        card_uuid: ["can't be blank"]
       } == errors_on(changeset)
     end
 
     test "fails for, assoc constraint, if tool box does not exist", context do
       %{tool_type: tool_type} = context
-      params = %{name: "Tool_1", status: "issued", tool_box_id: -1, tool_type_id: tool_type.id}
+      params = %{name: "Tool_1", status: "issued", tool_box_id: -1,
+        tool_type_id: tool_type.id, card_uuid: permalink(4)}
       assert {:error, changeset} = %Tool{} |> Tool.create_changeset(params) |> Repo.insert()
       assert %{tool_box: ["does not exist"]} == errors_on(changeset)
     end
 
     test "fails for assoc constraint tool type does not exist", context do
       %{tool_box: tool_box} = context
-      params = %{name: "Tool_1", status: "issued", tool_box_id: tool_box.id, tool_type_id: -1}
+      params = %{name: "Tool_1", status: "issued", tool_box_id: tool_box.id,
+        tool_type_id: -1, card_uuid: permalink(4)}
       assert {:error, changeset} = %Tool{} |> Tool.create_changeset(params) |> Repo.insert()
       assert %{tool_type: ["does not exist"]} == errors_on(changeset)
     end
@@ -43,14 +46,16 @@ defmodule Acqdat.Schema.ToolManagement.ToolTest do
       %{tool_box: tool_box, tool_type: tool_type} = context
       tool = insert(:tool, tool_box: tool_box, tool_type: tool_type)
 
-      params =  params = %{name: tool.name, status: "issued", tool_box_id: tool_box.id, tool_type_id: tool_type.id}
+      params = %{name: tool.name, status: "issued", tool_box_id: tool_box.id,
+        tool_type_id: tool_type.id, card_uuid: permalink(4)}
       assert {:error, changeset} = %Tool{} |> Tool.create_changeset(params) |> Repo.insert()
       assert %{name: ["Unique tool name per tool box!"]} == errors_on(changeset)
     end
 
     test "fails if status not in inclusion list", context do
       %{tool_type: tool_type, tool_box: tool_box} = context
-      params = %{name: "Tool_1", status: "xyz", tool_box_id: tool_box.id, tool_type_id: tool_type.id}
+      params = %{name: "Tool_1", status: "xyz", tool_box_id: tool_box.id,
+        tool_type_id: tool_type.id, card_uuid: permalink(4)}
       assert changeset = Tool.create_changeset(%Tool{}, params)
       assert %{status: ["is invalid"]} == errors_on(changeset)
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,23 @@ defmodule AcqdatWeb.ConnCase do
 
       # The default endpoint for testing
       @endpoint AcqdatWeb.Endpoint
+
+      @default_opts [
+        store: :cookie,
+        key: "secretkey",
+        encryption_salt: "encrypted cookie salt",
+        signing_salt: "signing salt"
+      ]
+      @signing_opts Plug.Session.init(Keyword.put(@default_opts, :encrypt, false))
+
+      def signin_guardian(conn, user) do
+        conn =
+          conn
+          |> Plug.Session.call(@signing_opts)
+          |> Plug.Conn.fetch_session()
+          |> AcqdatWeb.Guardian.Plug.sign_in(user)
+          |> Guardian.Plug.VerifySession.call([])
+      end
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -24,7 +24,7 @@ defmodule Acqdat.Support.Factory do
       first_name: "Tony",
       last_name: "Stark",
       email: "tony@starkindustries.com",
-      password_hash: ""
+      password_hash: "NOTASECRET"
     }
   end
 
@@ -81,7 +81,8 @@ defmodule Acqdat.Support.Factory do
       phone_number: "123456",
       address: "54 Peach Street, Gotham",
       role: "worker",
-      uuid: "U" <> permalink(4)
+      uuid: "U" <> permalink(4),
+      card_uuid: "U" <> permalink(4)
     }
   end
 
@@ -106,6 +107,7 @@ defmodule Acqdat.Support.Factory do
       status: "in_inventory",
       tool_box: build(:tool_box),
       tool_type: build(:tool_type),
+      card_uuid: "T" <> permalink(4)
     }
   end
 


### PR DESCRIPTION
At present difficulty to read card blocks of rfid cards
limits the functionality to write uuids and use them while
reading.
The commit adds card_uuid fields to employee and tools
records which can be input manually and read from the
app.

- Add schema migrations for card_uuid field in tools
 and employee table.
- Modify the logic for transaction, tool_verfication
  and employee_verification to use card_uuid instead
  of uuids.